### PR TITLE
Initialize uploadOp.

### DIFF
--- a/lib/functions/testproject.class.php
+++ b/lib/functions/testproject.class.php
@@ -784,6 +784,10 @@ function show(&$smarty,$guiObj,$template_dir,$id,$sqlResult='', $action = 'updat
     $gui->sqlResult = $sqlResult;
   }
 
+  if (!property_exists($gui, 'uploadOp')) {
+    $gui->uploadOp = null;
+  }
+  
   $p2ow = array('refreshTree' => false, 'user_feedback' => '');
   foreach ($p2ow as $prop => $value) {
     if (!property_exists($gui,$prop)) {


### PR DESCRIPTION
Get rid of warning:

E_NOTICE Undefined property: stdClass::$uploadOp - in /var/www/html/testlink_20/gui/templates_c/76eb5f555ccf675bff52dd7d6028bcdc30b128e0_0.file.containerView.tpl.php - Line 123

To reproduce, select TestSpecification page and look at warnings.